### PR TITLE
Create initial design time factory

### DIFF
--- a/src/Services/Enrolling/Enrolling.API/Startup.cs
+++ b/src/Services/Enrolling/Enrolling.API/Startup.cs
@@ -37,7 +37,7 @@ namespace OpenCodeFoundation.ESchool.Services.Enrolling.API
                         Configuration["ConnectionStrings"],
                         sqlServerOptionsAction: sqlOptions =>
                             {
-                                sqlOptions.MigrationsAssembly(typeof(Startup).GetTypeInfo().Assembly.GetName().Name);
+                                sqlOptions.MigrationsAssembly(typeof(EnrollingContext).GetTypeInfo().Assembly.GetName().Name);
                                 sqlOptions.EnableRetryOnFailure(maxRetryCount: 15, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null);
                             });
                 });

--- a/src/Services/Enrolling/Enrolling.Infrastructure/EnrollingContext.cs
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/EnrollingContext.cs
@@ -19,7 +19,7 @@ namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure
     ///     Helper class for creating migration. To create new migration, run the
     ///     command from `Enrolling.Intrastructure` folder.
     ///
-    ///     $ dotnet ef migrations add name_of_migration --startup-project ../Enrolling.API - ../Enrolling.API/Infrastructure/Migrations
+    ///     $ dotnet ef migrations add name_of_migration --startup-project ../Enrolling.API
     /// </summary>
     public class EnrollingContextFactory : IDesignTimeDbContextFactory<EnrollingContext>
     {

--- a/src/Services/Enrolling/Enrolling.Infrastructure/EnrollingContext.cs
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/EnrollingContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 using OpenCodeFoundation.ESchool.Services.Enrolling.Domain.AggregatesModel.EnrollmentAggregate;
 
 namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure
@@ -12,5 +13,22 @@ namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure
         }
 
         public DbSet<Enrollment> Enrollments { get; set; }
+    }
+
+    /// <summary>
+    ///     Helper class for creating migration. To create new migration, run the
+    ///     command from `Enrolling.Intrastructure` folder.
+    ///
+    ///     $ dotnet ef migrations add name_of_migration --startup-project ../Enrolling.API - ../Enrolling.API/Infrastructure/Migrations
+    /// </summary>
+    public class EnrollingContextFactory : IDesignTimeDbContextFactory<EnrollingContext>
+    {
+        public EnrollingContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<EnrollingContext>()
+                .UseSqlServer("Server=.;Initial Catalog=OpenCodeFoundation.EnrollingDb;Integrated Security=true");
+
+            return new EnrollingContext(optionsBuilder.Options);
+        }
     }
 }

--- a/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/20200330154056_Initial.Designer.cs
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/20200330154056_Initial.Designer.cs
@@ -7,17 +7,17 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure;
 
-namespace OpenCodeFoundation.ESchool.Services.Enrolling.API.Infrastructure.Migrations
+namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure.Migrations
 {
     [DbContext(typeof(EnrollingContext))]
-    [Migration("20190913125104_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20200330154056_Initial")]
+    partial class Initial
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "3.0.0-preview8.19405.11")
+                .HasAnnotation("ProductVersion", "3.1.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 

--- a/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/20200330154056_Initial.cs
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/20200330154056_Initial.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace OpenCodeFoundation.ESchool.Services.Enrolling.API.Infrastructure.Migrations
+namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure.Migrations
 {
-    public partial class InitialCreate : Migration
+    public partial class Initial : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/EnrollingContextModelSnapshot.cs
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/Migrations/EnrollingContextModelSnapshot.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure;
 
-namespace OpenCodeFoundation.ESchool.Services.Enrolling.API.Infrastructure.Migrations
+namespace OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure.Migrations
 {
     [DbContext(typeof(EnrollingContext))]
     partial class EnrollingContextModelSnapshot : ModelSnapshot
@@ -15,7 +15,7 @@ namespace OpenCodeFoundation.ESchool.Services.Enrolling.API.Infrastructure.Migra
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "3.0.0-preview8.19405.11")
+                .HasAnnotation("ProductVersion", "3.1.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 


### PR DESCRIPTION
This ensure that we can create new migration agains

To create new migration, run the command from `Enrolling.Intrastructure` folder -

```shell
$ dotnet ef migrations add name_of_migration --startup-project ../Enrolling.API - ../Enrolling.API/Infrastructure/Migrations
```

**Questions:**

- Do we need to store the migration files inside `Enrolling.API` project? Migration should be part of `Infrastructure` layer and be in there.

Closes #109