### PR TITLE
fix(enrolling): path source for code coverage

### DIFF
--- a/build/azure-devops/enrolling-api/azure-pipelines.yml
+++ b/build/azure-devops/enrolling-api/azure-pipelines.yml
@@ -4,12 +4,12 @@ trigger:
   paths:
     include:
       - src/Services/Enrolling/*
-      - build/azure-devops/*
+      - build/azure-devops/enrolling-api/*
 pr:
   paths:
     include:
       - src/Services/Enrolling/*
-      - build/azure-devops/*
+      - build/azure-devops/enrolling-api/*
 steps:
   - task: DockerCompose@0
     displayName: Build
@@ -43,4 +43,5 @@ steps:
     displayName: Publish test coverage
     inputs:
       codeCoverageTool: "cobertura" # Options: cobertura, jaCoCo
+      pathToSources: $(System.DefaultWorkingDirectory)/src/Services/Enrolling/
       summaryFileLocation: "$(Build.ArtifactStagingDirectory)/*/coverage.cobertura.xml"


### PR DESCRIPTION
Now we can check code coverage report with source code in graphical user interface in Azure DevOps pipeline result.

Also only run pipeline for enrolling pipeline change only. Currently any changes to any azure pipeline trigger the pipeline.

Closes #164