### PR TITLE
Update enrolling service to .NET 5.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,10 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.100-preview.6.20318.15'
+
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2

--- a/src/Services/Enrolling/Enrolling.API/Dockerfile
+++ b/src/Services/Enrolling/Enrolling.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 
 COPY "eSchool.sln" "eSchool.sln"

--- a/src/Services/Enrolling/Enrolling.API/Enrolling.API.csproj
+++ b/src/Services/Enrolling/Enrolling.API/Enrolling.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <AssemblyName>Enrolling.API</AssemblyName>
     <RootNamespace>OpenCodeFoundation.ESchool.Services.Enrolling.API</RootNamespace>
@@ -16,11 +16,11 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="3.1.1" />
 
     <!-- In-memory commandbus -->
-    <PackageReference Include="MediatR" Version="8.0.1" />
+    <PackageReference Include="MediatR" Version="8.0.2" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
 
     <!-- For validating inputs -->
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.0.1" />
 
     <!-- Polly is a .NET resilience and transient-fault-handling library that
     allows developers to express policies such as Retry, Circuit Breaker, Timeout,
@@ -35,7 +35,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
 
     <!-- Need this package for generating migration files -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0-preview.6.20312.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Services/Enrolling/Enrolling.Domain/Enrolling.Domain.csproj
+++ b/src/Services/Enrolling/Enrolling.Domain/Enrolling.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <AssemblyName>Enrolling.Domain</AssemblyName>
     <RootNamespace>OpenCodeFoundation.ESchool.Services.Enrolling.Domain</RootNamespace>

--- a/src/Services/Enrolling/Enrolling.FunctionalTests/Enrolling.FunctionalTests.csproj
+++ b/src/Services/Enrolling/Enrolling.FunctionalTests/Enrolling.FunctionalTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0-preview.6.20312.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/Services/Enrolling/Enrolling.FunctionalTests/Enrolling.FunctionalTests.csproj
+++ b/src/Services/Enrolling/Enrolling.FunctionalTests/Enrolling.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <RootNamespace>OpenCodeFoundation.ESchool.Services.Enrolling.FunctionalTests</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/Services/Enrolling/Enrolling.Infrastructure/Enrolling.Infrastructure.csproj
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/Enrolling.Infrastructure.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.6.20312.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-preview.6.20312.4" />
 
     <!-- Analyzers -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />

--- a/src/Services/Enrolling/Enrolling.Infrastructure/Enrolling.Infrastructure.csproj
+++ b/src/Services/Enrolling/Enrolling.Infrastructure/Enrolling.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <AssemblyName>Enrolling.Infrastructure</AssemblyName>
     <RootNamespace>OpenCodeFoundation.ESchool.Services.Enrolling.Infrastructure</RootNamespace>
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
 
     <!-- Analyzers -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />

--- a/src/Services/Enrolling/Enrolling.UnitTests/Enrolling.UnitTests.csproj
+++ b/src/Services/Enrolling/Enrolling.UnitTests/Enrolling.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 


### PR DESCRIPTION
.NET 5.0 is next version of framework which merge .NET framework and dotnet core to single version .NET 5. It is now in preview. But as an early adapter, I am starting the enrolling service first.


Closes #167 