### PR TITLE
feat(enrolling): replace deprecated `set-env` command

### DIFF
--- a/.github/workflows/enrolling.api.yml
+++ b/.github/workflows/enrolling.api.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: set image tag
-        run: echo "::set-env name=TAG::$(git tag --points-at HEAD | cut -c 2-4)"
+        run: echo "TAG=$(git tag --points-at HEAD | cut -c 2-4)" >> $GITHUB_ENV
 
       - name: build
         run: docker-compose build enrolling.api


### PR DESCRIPTION
The `set-env` command is deprecated and will be disabled on November 16th. That's why I am using the new way to set environment variable. 

Closes #235 