### PR TITLE
chore: add service required files to pipeline build trigger

### DIFF
--- a/.github/workflows/enrolling.api.yml
+++ b/.github/workflows/enrolling.api.yml
@@ -6,11 +6,17 @@ on:
       - "src/Services/Enrolling/**"
       - ".github/workflows/enrolling.api.yml"
       - "src/Libraries/OpenTelemetry/**"
+      - "eSchool.sln"
+      - "build/dotnet/**"
+      - "src/Directory.Build.props"
   pull_request:
     paths:
       - "src/Services/Enrolling/**"
       - ".github/workflows/enrolling.api.yml"
       - "src/Libraries/OpenTelemetry/**"
+      - "eSchool.sln"
+      - "build/dotnet/**"
+      - "src/Directory.Build.props"
 
 jobs:
   build:

--- a/.github/workflows/enrolling.api.yml
+++ b/.github/workflows/enrolling.api.yml
@@ -9,6 +9,11 @@ on:
       - "eSchool.sln"
       - "build/dotnet/**"
       - "src/Directory.Build.props"
+      - "docker-compose.yml"
+      - "docker-compose.override.yml"
+      - "docker-compose.dcproj"
+      - "docker-compose-test.yml"
+      - "docker-compose-test.override.yml"
   pull_request:
     paths:
       - "src/Services/Enrolling/**"
@@ -17,6 +22,11 @@ on:
       - "eSchool.sln"
       - "build/dotnet/**"
       - "src/Directory.Build.props"
+      - "docker-compose.yml"
+      - "docker-compose.override.yml"
+      - "docker-compose.dcproj"
+      - "docker-compose-test.yml"
+      - "docker-compose-test.override.yml"
 
 jobs:
   build:

--- a/.github/workflows/eschool.graphql.yml
+++ b/.github/workflows/eschool.graphql.yml
@@ -9,6 +9,11 @@ on:
       - "eSchool.sln"
       - "build/dotnet/**"
       - "src/Directory.Build.props"
+      - "docker-compose.yml"
+      - "docker-compose.override.yml"
+      - "docker-compose.dcproj"
+      - "docker-compose-test.yml"
+      - "docker-compose-test.override.yml"
   pull_request:
     paths:
       - "src/ApiGateways/eSchool.GraphQL/**"
@@ -17,6 +22,11 @@ on:
       - "eSchool.sln"
       - "build/dotnet/**"
       - "src/Directory.Build.props"
+      - "docker-compose.yml"
+      - "docker-compose.override.yml"
+      - "docker-compose.dcproj"
+      - "docker-compose-test.yml"
+      - "docker-compose-test.override.yml"
 
 jobs:
   build:

--- a/.github/workflows/eschool.graphql.yml
+++ b/.github/workflows/eschool.graphql.yml
@@ -6,11 +6,17 @@ on:
       - "src/ApiGateways/eSchool.GraphQL/**"
       - ".github/workflows/eschool.graphql.yml"
       - "src/Libraries/OpenTelemetry/**"
+      - "eSchool.sln"
+      - "build/dotnet/**"
+      - "src/Directory.Build.props"
   pull_request:
     paths:
       - "src/ApiGateways/eSchool.GraphQL/**"
       - ".github/workflows/eschool.graphql.yml"
       - "src/Libraries/OpenTelemetry/**"
+      - "eSchool.sln"
+      - "build/dotnet/**"
+      - "src/Directory.Build.props"
 
 jobs:
   build:

--- a/.github/workflows/frontend.blazor.yml
+++ b/.github/workflows/frontend.blazor.yml
@@ -3,12 +3,18 @@ name: Frontend.Blazor
 on:
   push:
     paths:
-    - 'src/Web/Frontend.Blazor/**'
-    - '.github/workflows/frontend.blazor.yml'
+    - "src/Web/Frontend.Blazor/**"
+    - ".github/workflows/frontend.blazor.yml"
+    - "eSchool.sln"
+    - "build/dotnet/**"
+    - "src/Directory.Build.props"
   pull_request:
     paths:
-    - 'src/Web/Frontend.Blazor/**'
-    - '.github/workflows/frontend.blazor.yml'
+    - "src/Web/Frontend.Blazor/**"
+    - ".github/workflows/frontend.blazor.yml"
+    - "eSchool.sln"
+    - "build/dotnet/**"
+    - "src/Directory.Build.props"
 
 jobs:
 

--- a/.github/workflows/frontend.blazor.yml
+++ b/.github/workflows/frontend.blazor.yml
@@ -8,6 +8,11 @@ on:
     - "eSchool.sln"
     - "build/dotnet/**"
     - "src/Directory.Build.props"
+    - "docker-compose.yml"
+    - "docker-compose.override.yml"
+    - "docker-compose.dcproj"
+    - "docker-compose-test.yml"
+    - "docker-compose-test.override.yml"
   pull_request:
     paths:
     - "src/Web/Frontend.Blazor/**"
@@ -15,6 +20,11 @@ on:
     - "eSchool.sln"
     - "build/dotnet/**"
     - "src/Directory.Build.props"
+    - "docker-compose.yml"
+    - "docker-compose.override.yml"
+    - "docker-compose.dcproj"
+    - "docker-compose-test.yml"
+    - "docker-compose-test.override.yml"
 
 jobs:
 

--- a/.github/workflows/webstatus.yml
+++ b/.github/workflows/webstatus.yml
@@ -3,12 +3,18 @@ name: WebStatus
 on:
   push:
     paths:
-    - 'src/Web/WebStatus/**'
-    - '.github/workflows/webstatus.yml'
+    - "src/Web/WebStatus/**"
+    - ".github/workflows/webstatus.yml"
+    - "eSchool.sln"
+    - "build/dotnet/**"
+    - "src/Directory.Build.props"
   pull_request:
     paths:
-    - 'src/Web/WebStatus/**'
-    - '.github/workflows/webstatus.yml'
+    - "src/Web/WebStatus/**"
+    - ".github/workflows/webstatus.yml"
+    - "eSchool.sln"
+    - "build/dotnet/**"
+    - "src/Directory.Build.props"
 
 jobs:
 

--- a/.github/workflows/webstatus.yml
+++ b/.github/workflows/webstatus.yml
@@ -8,6 +8,11 @@ on:
     - "eSchool.sln"
     - "build/dotnet/**"
     - "src/Directory.Build.props"
+    - "docker-compose.yml"
+    - "docker-compose.override.yml"
+    - "docker-compose.dcproj"
+    - "docker-compose-test.yml"
+    - "docker-compose-test.override.yml"
   pull_request:
     paths:
     - "src/Web/WebStatus/**"
@@ -15,6 +20,11 @@ on:
     - "eSchool.sln"
     - "build/dotnet/**"
     - "src/Directory.Build.props"
+    - "docker-compose.yml"
+    - "docker-compose.override.yml"
+    - "docker-compose.dcproj"
+    - "docker-compose-test.yml"
+    - "docker-compose-test.override.yml"
 
 jobs:
 


### PR DESCRIPTION
Currently there are some files where if any changes is made, service specific build can fail. But as there is no build trigger for those file changes, the error can go un-noticed in PR.