### PR TITLE
chore(deps): bump OpenTelemetry from 1.0.0-rc5 to 1.0.0-rc6

### DIFF
--- a/src/Libraries/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/Libraries/OpenTelemetry/OpenTelemetry.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0"/>
     <!-- OpenTelemetry -->
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc5"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc5"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc5"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc5"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc6"/>
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION


Related: #451 #452 #453 #454 